### PR TITLE
Add Go modules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,26 @@
+SHELL := bash
+
+# Default - top level rule is what gets run when you run just 'make' without specifying a goal/target.
+.DEFAULT_GOAL := demo
+
+.DELETE_ON_ERROR:
+.ONESHELL:
+.SHELLFLAGS := -euo pipefail -c
+
+MAKEFLAGS += --no-builtin-rules
+MAKEFLAGS += --warn-undefined-variables
+
+ifeq ($(origin .RECIPEPREFIX), undefined)
+  $(error This Make does not support .RECIPEPREFIX. Please use GNU Make 4.0 or later.)
+endif
+.RECIPEPREFIX = >
+
+# Adjust the width of the first column by changing the '-20s' value in the printf pattern.
+help:
+> @grep -E '^[a-zA-Z0-9_-]+:.*? ## .*$$' $(MAKEFILE_LIST) | sort \
+> | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}'
+.PHONY: help
+
+demo: ## Shows execution flow and interface substitution.
+> go test github.com/err0r500/Clean-Architecture-in-Golang/src -count=1 -run="^TestUsesCases$$" -v
+.PHONY: demo

--- a/README.md
+++ b/README.md
@@ -2,16 +2,19 @@
 
 [![BCH compliance](https://bettercodehub.com/edge/badge/Err0r500/Clean-Architecture-in-Golang?branch=master)](https://bettercodehub.com/)
 
->The purpose of this architecture is to be as flexible as possible in order to develop a project as quickly as possible and to maintain this speed during the whole development lifespan, whatever its size and the changes that will have to be done, for whatever reason.
+> The purpose of this architecture is to be as flexible as possible in order to develop a project as quickly as possible and to maintain this speed during the whole development lifespan, whatever its size and the changes that will have to be done, for whatever reason.
 
-### Complete Go App using this architecture : 
+## Complete Go App using this architecture
+
 [err0r500/go-realworld-clean](https://github.com/err0r500/go-realworld-clean)
 
-### Detailed explanation of this repo :
+## Detailed explanation of this repo
+
 [Hands-On Clean Architecture](https://medium.com/@matthieujacquotdev/clean-architecture-in-golang-7ebafe4c70db)
 
+## Demo
 
-### Demo :
-run main_test.go and read the logs to see
-- how the execution flows from a layer to another while the dependency inversion rule is strictly observed.
+Run `make demo` and read the logs from `src/main_test.go` to see:
+
+- how the execution flows from a layer to another while the dependency inversion rule is strictly observed
 - how an Interface can be substituted to another allowing us to plug IN/OUT dependencies

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,7 @@
+module github.com/err0r500/Clean-Architecture-in-Golang
+
+go 1.15
+
+require github.com/err0r500/cleanArchitectureGolang v0.0.0
+
+replace github.com/err0r500/cleanArchitectureGolang v0.0.0 => ./


### PR DESCRIPTION
Hi there, and thank you for this repo!
It's great to have a worked example of the clean architecture concepts to follow along with.

I have added a basic `go.mod` file to implement Go modules, so that the demo test code can be executed outside of `GOPATH`.

There is also a simple Makefile with a `demo` target, and corresponding README update to describe this.

In the `go.mod` file, the `require` and `replace` directives were necessary as the `import` statements throughout the Go code do not align with its actual location on the internet, but updating all of the `import` lines would make for a much larger PR, so I've left those as-is.

Hope this helps!